### PR TITLE
metadata: add repository

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //!
 //! - Homepage: https://github.com/yoshuawuyts/human-panic
 //! - Authors: Yoshua Wuyts <yoshuawuyts@gmail.com>
+//! - Repository: https://github.com/yoshuawuyts/human-panic
 //!
 //! We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.
 //!
@@ -70,6 +71,8 @@ pub struct Metadata {
   pub authors: Cow<'static, str>,
   /// The URL of the crate's website
   pub homepage: Cow<'static, str>,
+  /// The URL of the crate's repository
+  pub repository: Cow<'static, str>,
 }
 
 /// `human-panic` initialisation macro
@@ -90,6 +93,7 @@ pub struct Metadata {
 ///     version: env!("CARGO_PKG_VERSION").into(),
 ///     authors: "My Company Support <support@mycompany.com".into(),
 ///     homepage: "support.mycompany.com".into(),
+///     repository: "https://git.mycompany.com/repo.git".into(),
 /// });
 /// ```
 #[macro_export]
@@ -127,6 +131,7 @@ macro_rules! setup_panic {
           name: env!("CARGO_PKG_NAME").into(),
           authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
           homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+          repository: option_env!("CARGO_PKG_REPOSITORY").unwrap_or("").into(),
         };
 
         panic::set_hook(Box::new(move |info: &PanicInfo| {
@@ -145,8 +150,13 @@ pub fn print_msg<P: AsRef<Path>>(
   file_path: Option<P>,
   meta: &Metadata,
 ) -> IoResult<()> {
-  let (_version, name, authors, homepage) =
-    (&meta.version, &meta.name, &meta.authors, &meta.homepage);
+  let (_version, name, authors, homepage, repository) = (
+    &meta.version,
+    &meta.name,
+    &meta.authors,
+    &meta.homepage,
+    &meta.repository,
+  );
 
   let stderr = BufferWriter::stderr(ColorChoice::Auto);
   let mut buffer = stderr.buffer();
@@ -176,6 +186,9 @@ pub fn print_msg<P: AsRef<Path>>(
   }
   if !authors.is_empty() {
     writeln!(&mut buffer, "- Authors: {}", authors)?;
+  }
+  if !repository.is_empty() {
+    writeln!(&mut buffer, "- Repository: {}", repository)?;
   }
   writeln!(
     &mut buffer,

--- a/tests/custom-panic/src/main.rs
+++ b/tests/custom-panic/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
     version: env!("CARGO_PKG_VERSION").into(),
     authors: "My Company Support <support@mycompany.com".into(),
     homepage: "support.mycompany.com".into(),
+    repository: "https://git.mycompany.com/repo.git".into(),
   });
 
   println!("A normal log message");


### PR DESCRIPTION
Cargo guidelines are to not set a homepage if it isn't any different
than the repository URL. This causes the report to not have any link
back to file an issue. If the repository is available, print it as well.

---
Note that I've tried to find a reference to the "don't set `homepage` if it isn't the same" guideline, but haven't found it yet.

The environment variable is not available yet. See https://github.com/rust-lang/cargo/pull/6096

**Choose one:** is this a 🙋 feature?

## Checklist
- [x] tests pass
- [x] documentation is changed or added

## Context
None

## Semver Changes
Major; the `Metadata` structure has a new field that isn't specified in existing code.