### PR TITLE
Make report mod public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ extern crate failure;
 extern crate serde_derive;
 extern crate termcolor;
 
-mod report;
+pub mod report;
 use report::{Method, Report};
 
 use std::borrow::Cow;

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,3 +1,8 @@
+//! This module encapsulates the report of a failure event.
+//!
+//! A `Report` contains the metadata collected about the event
+//! to construct a helpful error message.
+
 extern crate failure;
 extern crate os_type;
 extern crate serde;
@@ -16,9 +21,14 @@ use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 /// Method of failure.
 #[derive(Debug, Serialize, Clone, Copy)]
 pub enum Method {
+  /// Failure caused by a panic.
   Panic,
 }
 
+/// Contains metadata about the crash like the backtrace and
+/// information about the crate and operating system. Can
+/// be used to be serialized and persisted or printed as
+/// information to the user.
 #[derive(Debug, Serialize)]
 pub struct Report {
   name: String,
@@ -119,6 +129,7 @@ impl Report {
     }
   }
 
+  /// Serialize the `Report` to a TOML string.
   pub fn serialize(&self) -> Option<String> {
     toml::to_string_pretty(&self).ok()
   }


### PR DESCRIPTION
**Choose one:** 🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
Hi! 👋 I was wondering if you'd be opposed to the idea of exposing the `report` mod as public. It is pretty useful on its own and I intend to use the `Report` struct directly instead of printing the result.

No worries if you don't want to increase the API surface, though. :)

## Semver Changes
<!-- Which semantic version change would you recommend? -->

It changes the public interface, but in a backwards-compatible way. So minor bump should be fine.
