### PR TITLE
🐛 fix: Update Rust versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix: # additional tests
   include:
   - rust: nightly
     script: cargo test --all --features nightly
-  - rust: 1.29.1
+  - rust: 1.35.0
     env: CLIPPY=YESPLEASE
     before_script: rustup component add clippy-preview
     script: cargo clippy --all -- -D warnings
-  - rust: 1.29.1
+  - rust: 1.35.0
     env: RUSTFMT=YESPLEASE
     before_script: rustup component add rustfmt-preview
     script: cargo fmt --all -- --check


### PR DESCRIPTION
Travis is currently red because because `clippy` and `rustfmt` have changed since 1.29. I guess the 1.25 special case is there for a reason so I didn't remove it, but it's currently failing because `backtrace` doesn't seem to be compatible anymore.

This would at least restore two green check marks :)
https://travis-ci.org/passy/human-panic/builds/548179069