### PR TITLE
Update to 2018 edition and prune dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 rust:
   - stable
   - beta
-  - 1.25.0
+  - 1.36.0
 script: |
   cargo build --verbose &&
   cargo test  --verbose --all
@@ -10,11 +10,11 @@ matrix: # additional tests
   include:
   - rust: nightly
     script: cargo test --all --features nightly
-  - rust: 1.29.1
+  - rust: 1.36.0
     env: CLIPPY=YESPLEASE
     before_script: rustup component add clippy-preview
     script: cargo clippy --all -- -D warnings
-  - rust: 1.29.1
+  - rust: 1.36.0
     env: RUSTFMT=YESPLEASE
     before_script: rustup component add rustfmt-preview
     script: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,17 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>",
            "Pascal Hertleif <killercup@gmail.com>",
            "Katharina Fey <kookie@spacekookie.de>"]
 readme = "README.md"
+edition = "2018"
 
 [package.metadata.docs.rs]
 features = ["nightly"]
 
 [dependencies]
 termcolor = "1.0.4"
-tempdir = "0.3.7"
-uuid = { version = "0.7.1", features = ["v4"] }
+uuid = { version = "0.7.1", features = ["v4"], default-features = false }
 serde_derive = "1.0.79"
 toml = "0.4.7"
 serde = "1.0.79"
-failure = { version = "0.1.2", default-features = false, features = ["std"] }
 os_type = "2.2.0"
 backtrace = "0.3.9"
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ stack backtrace:
 ## Usage
 
 ```rust no_run
-#[macro_use]
-extern crate human_panic;
+use human_panic::setup_panic;
 
 fn main() {
    setup_panic!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,13 +45,6 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", feature(panic_info_message))]
 
-extern crate backtrace;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate serde_derive;
-extern crate termcolor;
-
 pub mod report;
 use report::{Method, Report};
 
@@ -84,9 +77,8 @@ pub struct Metadata {
 /// The Metadata struct can't implement `Default` because of orphan rules, which
 /// means you need to provide all fields for initialisation.
 ///
-/// ```ignore
-/// #[macro_use]
-/// extern crate human_panic;
+/// ```
+/// use human_panic::setup_panic;
 ///
 /// setup_panic!(Metadata {
 ///     name: env!("CARGO_PKG_NAME").into(),

--- a/tests/custom-panic/Cargo.toml
+++ b/tests/custom-panic/Cargo.toml
@@ -2,9 +2,10 @@
 name = "custom-panic-test"
 version = "0.1.0"
 authors = ["Human Panic Authors <human-panic-crate@example.com>"]
+edition = "2018"
 
 [dependencies]
 human-panic = { path = "../.." }
 
 [dev-dependencies]
-assert_cli = "0.5.4"
+assert_cli = "0.6.3"

--- a/tests/custom-panic/src/main.rs
+++ b/tests/custom-panic/src/main.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate human_panic;
+use human_panic::setup_panic;
 
 fn main() {
   setup_panic!(Metadata {

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -1,4 +1,4 @@
-extern crate assert_cli;
+use assert_cli;
 
 #[test]
 fn release() {

--- a/tests/single-panic/Cargo.toml
+++ b/tests/single-panic/Cargo.toml
@@ -2,9 +2,10 @@
 name = "single-panic-test"
 version = "0.1.0"
 authors = ["Human Panic Authors <human-panic-crate@example.com>"]
+edition = "2018"
 
 [dependencies]
 human-panic = { path = "../.." }
 
 [dev-dependencies]
-assert_cli = "0.5.4"
+assert_cli = "0.6.3"

--- a/tests/single-panic/src/main.rs
+++ b/tests/single-panic/src/main.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate human_panic;
+use human_panic::setup_panic;
 
 fn main() {
   setup_panic!();

--- a/tests/single-panic/tests/integration.rs
+++ b/tests/single-panic/tests/integration.rs
@@ -1,4 +1,4 @@
-extern crate assert_cli;
+use assert_cli;
 
 #[test]
 fn release() {


### PR DESCRIPTION
Update the project to 2018 edition in both code and documentation for
usage, prunes unused dependencies and removes dependency on failure,
preferring the std Error trait.

There was also a misleading error message about not being able to find a
temporary file directory, which would have actually have been caused by
a failure to encode a filepath into UTF-8
(https://doc.rust-lang.org/src/std/path.rs.html#1848-1850). However this
error should not happen anyway by just using the PathBuf directly to
make the full path for the persisted file output.

Should resolve https://github.com/rust-cli/human-panic/issues/57

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
Feature and docs

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
https://github.com/rust-cli/human-panic/issues/57

## Semver Changes
<!-- Which semantic version change would you recommend? -->
Should take a minor bump potentially, but no changes to APIs.