### PR TITLE
🐛 Update minimum supported Rust version to 1.32.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: rust
 rust:
   - stable
   - beta
-  - 1.25.0
+  # Minimum supported Rust version (msrv)
+  - 1.32.0
 script: |
   cargo build --verbose &&
   cargo test  --verbose --all


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** 🐛 bug fix

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

This change bumps the minimum supported Rust version (msrv) to 1.32.0
due to updates in the [backtrace] crate. The update in backtrace was
made in May 2019 ([src][1]) and was later refactored when the CI/build
system was migrated to GitHub Actions ([src][2]). Consequently, either
we'll need to pin the version of backtrace in this crate or ride the
upstream updates and bump the "msrv" accordingly here.

This change assumes that #60 or a similar changeset is also merged which
together should restore the CI to green across the matrix.

[backtrace]: https://crates.io/crates/backtrace
[1]:
https://github.com/rust-lang/backtrace-rs/commit/83744e430271381f0f9a8636fa37fa647820fa45
[2]:
https://github.com/rust-lang/backtrace-rs/blob/816a9559c116f1224c9d3ac968bdc1e6be14fcf1/.github/workflows/main.yml#L196-L205


## Semver Changes
<!-- Which semantic version change would you recommend? -->

None strictly, although the supported version range of Rust is altered. However, this reflects the current reality so… :wink:

## Finally…

Note that this PR won't pass CI **by design**--as the lint and formatting branches are older Rust versions they will continue to fail. Sorry about a "successful" PR that "fails".

![tenor-31288478](https://user-images.githubusercontent.com/261548/66600704-544af900-eb63-11e9-9c0b-132d96c430cd.gif)
