### PR TITLE
Include cause, whether on nightly or not

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,14 +199,22 @@ pub fn print_msg<P: AsRef<Path>>(
 /// Utility function which will handle dumping information to disk
 pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   let mut expl = String::new();
+
   #[cfg(feature = "nightly")]
-  let message = panic_info.message();
+  let message = panic_info.message().map(|m| format!("{}", m));
 
   #[cfg(not(feature = "nightly"))]
-  let message = panic_info.payload().downcast_ref::<&str>();
+  let message = match (
+    panic_info.payload().downcast_ref::<&str>(),
+    panic_info.payload().downcast_ref::<String>(),
+  ) {
+    (Some(s), _) => Some(s.to_string()),
+    (_, Some(s)) => Some(s.to_string()),
+    (None, None) => None,
+  };
 
   let cause = match message {
-    Some(m) => format!("{}", m),
+    Some(m) => m,
     None => "Unknown".into(),
   };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,19 +200,15 @@ pub fn print_msg<P: AsRef<Path>>(
 pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   let mut expl = String::new();
   #[cfg(feature = "nightly")]
-  let cause = match panic_info.message() {
+  let message = panic_info.message();
+
+  #[cfg(not(feature = "nightly"))]
+  let message = panic_info.payload().downcast_ref::<&str>();
+
+  let cause = match message {
     Some(m) => format!("{}", m),
     None => "Unknown".into(),
   };
-
-  #[cfg(not(feature = "nightly"))]
-  let cause =
-    String::from("Error cause could not be determined by the application.");
-
-  let payload = panic_info.payload().downcast_ref::<&str>();
-  if let Some(payload) = payload {
-    expl.push_str(&format!("Cause: {}. ", &payload));
-  }
 
   match panic_info.location() {
     Some(location) => expl.push_str(&format!(


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

🐛 Set `cause`, whether we're on nightly or not.

Previously there were two cases with two sub-cases:
- if compiled with nightly:
    - if there is a panic message: set it as `cause`
    - if there is no panic message: set `cause` to "Unknown"
- if not compiled with nightly: set cause to "Error cause could not be determined by the application.", _and also:_
    - if there is a panic message: attach it straight to the `expl` string as "Cause: <cause>."

That seems oddly complicated. This PR changes that to:
- if there is a panic message (no matter if we're on nightly or not): set it as `cause`
- if there is no panic message (no matter if we're on nightly or not): set `cause` to "Unknown"

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
Vaguely related to https://github.com/rust-cli/human-panic/issues/55.

## Semver Changes
This changes the format of the message users see. I think it's a bugfix, but if changing what users see is considered a breaking change, then this is a breaking change.
