### PR TITLE
Change Travis links from rust-clique to rust-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ $ cargo add human-panic
 
 [1]: https://img.shields.io/crates/v/human-panic.svg?style=flat-square
 [2]: https://crates.io/crates/human-panic
-[3]: https://img.shields.io/travis/rust-clique/human-panic.svg?style=flat-square
-[4]: https://travis-ci.org/rust-clique/human-panic
+[3]: https://img.shields.io/travis/rust-cli/human-panic.svg?style=flat-square
+[4]: https://travis-ci.org/rust-cli/human-panic
 [5]: https://img.shields.io/crates/d/human-panic.svg?style=flat-square
 [6]: https://crates.io/crates/human-panic
 [7]: https://docs.rs/human-panic/badge.svg


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

🔦 Fix Travis links in README badge - **[see preview](https://github.com/curiousleo/human-panic/blob/patch-1/README.md)**.

<!-- Provide a general summary of the changes in the title above -->

https://travis-ci.org/rust-clique/human-panic does not exist.
The correct link is https://travis-ci.org/rust-cli/human-panic.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

Nope.

## Semver Changes
<!-- Which semantic version change would you recommend? -->

No release required.