### PR TITLE
README: Clarify that release mode is needed in order to use human-panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ fn main() {
 }
 ```
 
+It only displays a human-friendly panic message in release mode:
+
+```sh
+$ cargo run --release
+```
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
I just spent about twenty minutes debugging why human-panic wasn't working.

I hadn't enabled release mode and had no idea that release mode affected it.

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

This is a 🔦 documentation change.

## Checklist
- [x] documentation is changed or added

## Context
N/A

## Semver Changes
None
