### PR TITLE
Use os_info instead of os_type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "0.8.0", features = ["v4"], default-features = false }
 serde_derive = "1.0.79"
 toml = "0.5.0"
 serde = "1.0.79"
-os_type = "2.2.0"
+os_info = "2.0.6"
 backtrace = "0.3.9"
 
 [features]

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,7 +5,6 @@
 
 use backtrace::Backtrace;
 use serde_derive::Serialize;
-use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::Write as FmtWrite;
 use std::mem;
@@ -26,7 +25,7 @@ pub enum Method {
 #[derive(Debug, Serialize)]
 pub struct Report {
   name: String,
-  operating_system: Cow<'static, str>,
+  operating_system: String,
   crate_version: String,
   explanation: String,
   cause: String,
@@ -43,12 +42,7 @@ impl Report {
     explanation: String,
     cause: String,
   ) -> Self {
-    let operating_system = if cfg!(windows) {
-      "windows".into()
-    } else {
-      let platform = os_type::current_platform();
-      format!("unix:{:?}", platform.os_type).into()
-    };
+    let operating_system = os_info::get().to_string();
 
     //We skip 3 frames from backtrace library
     //Then we skip 3 frames for our own library


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

It is a bit controversial, because I'm the maintainer of the `os_info` crate, but it can detect Windows, so `cfg!(windows)` is no longer needed. Additionally, this crate can obtain the Windows version and support more platforms.

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
N/A

## Semver Changes
<!-- Which semantic version change would you recommend? -->
Not sure.

The format of the `operating_system` field of the `Report` has changed, but I'm not sure if it is considered a part of the API.
