### PR TITLE
Explain where setup_panic!() should be called

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ macro_rules! metadata {
 /// The Metadata struct can't implement `Default` because of orphan rules, which
 /// means you need to provide all fields for initialisation.
 ///
+/// The macro should be called from within a function, for example as the first line of the
+/// `main()` function of the program.
+///
 /// ```
 /// use human_panic::setup_panic;
 ///


### PR DESCRIPTION
This explanation was missing from the macro documentation.

Closes #76 