### PR TITLE
chore: Test fix for #109, run in full in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
     - name: Build Debug
-      run: cargo test --no-run
+      run: cargo test --all --no-run
     - name: Test Debug
-      run: cargo test
+      run: cargo test --all
     - name: Build Release
-      run: cargo test --no-run --release
+      run: cargo test --all --no-run --release
     - name: Test Release
-      run: cargo test --release
+      run: cargo test --all --release
   msrv:
     name: "Check MSRV: 1.65.0"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "name-collision-test"
+version = "0.1.0"
+dependencies = [
+ "human-panic",
+ "snapbox",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "tests/single-panic",
   "tests/custom-panic",
+  "tests/name-collision",
 ]
 resolver = "2"
 

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -29,7 +29,7 @@ fn debug() {
         .assert()
         .stderr_matches(
             "\
-thread 'main' panicked at 'OMG EVERYTHING IS ON FIRE!!!', tests/custom-panic/src/main.rs:12:3
+thread 'main' panicked at 'OMG EVERYTHING IS ON FIRE!!!', tests/custom-panic/src/main.rs:12:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ",
         )

--- a/tests/name-collision/Cargo.toml
+++ b/tests/name-collision/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "name-collision-test"
+version = "0.1.0"
+authors = ["Human Panic Authors <human-panic-crate@example.com>"]
+edition = "2018"
+
+[package.metadata.release]
+release = false
+
+[dependencies]
+human-panic = { path = "../.." }
+
+[dev-dependencies]
+snapbox = { version = "0.4.11", features = ["cmd"] }

--- a/tests/name-collision/src/main.rs
+++ b/tests/name-collision/src/main.rs
@@ -1,0 +1,25 @@
+use human_panic::setup_panic;
+
+#[derive(Debug, PartialEq)]
+struct Metadata {
+    test: bool,
+}
+
+mod panic {
+    pub fn what() {}
+}
+
+fn main() {
+    panic::what();
+    let prev = Metadata { test: true };
+
+    setup_panic!();
+
+    let next = Metadata { test: false };
+
+    assert_ne!(prev, next);
+    panic::what();
+
+    println!("A normal log message");
+    panic!("OMG EVERYTHING IS ON FIRE!!!");
+}

--- a/tests/name-collision/tests/integration.rs
+++ b/tests/name-collision/tests/integration.rs
@@ -1,15 +1,15 @@
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn release() {
-    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("single-panic-test"))
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("name-collision-test"))
     .assert()
     .stderr_matches(
       "\
 Well, this is embarrassing.
 
-single-panic-test had a problem and crashed. To help us diagnose the problem you can send us a crash report.
+name-collision-test had a problem and crashed. To help us diagnose the problem you can send us a crash report.
 
-We have generated a report file at \"[..].toml\". Submit an issue or email with the subject of \"single-panic-test Crash Report\" and include the report as an attachment.
+We have generated a report file at \"[..].toml\". Submit an issue or email with the subject of \"name-collision-test Crash Report\" and include the report as an attachment.
 
 - Authors: Human Panic Authors <human-panic-crate@example.com>
 
@@ -24,11 +24,11 @@ Thank you kindly!
 #[test]
 #[cfg_attr(not(debug_assertions), ignore)]
 fn debug() {
-    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("single-panic-test"))
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("name-collision-test"))
         .assert()
         .stderr_matches(
             "\
-thread 'main' panicked at 'OMG EVERYTHING IS ON FIRE!!!', tests/single-panic/src/main.rs:7:5
+thread 'main' panicked at 'OMG EVERYTHING IS ON FIRE!!!', tests/name-collision/src/main.rs:24:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ",
         )


### PR DESCRIPTION
The other tests only needed modified to fix a column number. The action was mysteriously only running one of the tests - I've fixed that.

This should help prevent regressions for #109 and possibly others. I've verified they also failed prior to that patch.